### PR TITLE
Request fallbacks

### DIFF
--- a/lua/otter/completion/source.lua
+++ b/lua/otter/completion/source.lua
@@ -24,7 +24,7 @@ end
 ---Determine if the cursor is in a code context for the otter language.
 ---associated with this source.
 ---@return boolean
-source.is_otter_context = function(self)
+source.is_otter_lang_context = function(self)
   local language_tree = ts.get_parser(self.main_nr, self.main_parsername)
   local syntax_tree = language_tree:parse()
   local root = syntax_tree[1]:root()
@@ -35,7 +35,7 @@ source.is_otter_context = function(self)
 
   local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   row = row - 1
-  col = col - 1
+  col = col
 
   -- get text ranges
   for pattern, match, metadata in query:iter_matches(root, self.main_nr) do
@@ -79,7 +79,7 @@ source.is_available = function(self)
   -- client is not attached to current buffer.
 
   -- disable completion outside of language context
-  if not self:is_otter_context() then
+  if not self:is_otter_lang_context() then
     return false
   end
 

--- a/lua/otter/init.lua
+++ b/lua/otter/init.lua
@@ -40,8 +40,7 @@ M.ask_definition = function()
     end
     return modified_response
   end,
-  vim.lsp.buf.definition
-
+    vim.lsp.buf.definition
   )
 end
 
@@ -60,8 +59,8 @@ M.ask_hover = function()
     else
       return response
     end
-  end, 
-  vim.lsp.buf.hover
+  end,
+    vim.lsp.buf.hover
   )
 end
 

--- a/lua/otter/init.lua
+++ b/lua/otter/init.lua
@@ -39,7 +39,9 @@ M.ask_definition = function()
       table.insert(modified_response, redirect_definition(res))
     end
     return modified_response
-  end
+  end,
+  vim.lsp.buf.definition
+
   )
 end
 
@@ -58,7 +60,9 @@ M.ask_hover = function()
     else
       return response
     end
-  end)
+  end, 
+  vim.lsp.buf.hover
+  )
 end
 
 

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -9,8 +9,8 @@ local extensions = require 'otter.tools.extensions'
 local api = vim.api
 local ts = vim.treesitter
 local parsers = require 'nvim-treesitter.parsers'
-local handlers = require'otter.tools.handlers'
-local config = require'otter.config'.config
+local handlers = require 'otter.tools.handlers'
+local config = require 'otter.config'.config
 
 
 M._otters_attached = {}

--- a/lua/otter/tools/functions.lua
+++ b/lua/otter/tools/functions.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local context = require 'cmp.config.context'
+local ts = vim.treesitter
+local parsers = require 'nvim-treesitter.parsers'
+
 M.contains = function(list, x)
   for _, v in pairs(list) do
     if v == x then return true end
@@ -52,6 +56,38 @@ end
 --- @param path string
 M.is_otterpath = function(path)
   return path:find('.+-tmp%..+') ~= nil
+end
+
+---Determine if the cursor is in any otter context, irrespective of the language
+---@return boolean
+M.is_otter_context = function(main_nr, tsquery)
+  local ft = vim.api.nvim_buf_get_option(main_nr, 'filetype')
+  local parsername = parsers.ft_to_lang(ft) or ft
+  local language_tree = ts.get_parser(main_nr, parsername)
+  local syntax_tree = language_tree:parse()
+  local root = syntax_tree[1]:root()
+
+  -- create capture
+  local query = ts.parse_query(parsername, tsquery)
+
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  row = row - 1
+  col = col
+
+  -- get text ranges
+  for pattern, match, metadata in query:iter_matches(root, main_nr) do
+    -- each match has two nodes, the language and the code
+    -- the language node is the first one
+    for id, node in pairs(match) do
+      local name = query.captures[id]
+      local ok, text = pcall(ts.query.get_node_text, node, 0)
+      if not ok then return false end
+      if name == 'code' and ts.is_in_node_range(node, row, col) then
+        return true
+      end
+    end
+  end
+  return false
 end
 
 return M


### PR DESCRIPTION
sending lsp requests to otter buffers now also takes a fallback function to call when not in an otter context.
This enables e.g. handling requests to an lsp server attached to the main buffer normally and having otter handle the requests to embedded contexts.