### PR TITLE
Set buftype=nowrite for otter buffers

### DIFF
--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -146,6 +146,7 @@ M.activate = function(languages, completion, tsqueries)
     local otter_nr = vim.uri_to_bufnr(otter_uri)
     api.nvim_buf_set_name(otter_nr, otter_path)
     api.nvim_buf_set_option(otter_nr, 'swapfile', false)
+    api.nvim_buf_set_option(otter_nr, 'buftype', 'nowrite')
     M._otters_attached[main_nr].buffers[lang] = otter_nr
     ::continue::
   end
@@ -156,23 +157,6 @@ M.activate = function(languages, completion, tsqueries)
   for lang, otter_nr in pairs(M._otters_attached[main_nr].buffers) do
     api.nvim_buf_set_option(otter_nr, 'filetype', lang)
   end
-
-  -- auto-close language files on qmd file close
-  api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
-    buffer = 0,
-    group = api.nvim_create_augroup("OtterAutoclose", {}),
-    callback = function(_, _)
-      for _, bufnr in pairs(M._otters_attached[main_nr].buffers) do
-        if api.nvim_buf_is_valid(bufnr) then
-          -- delete otter buffer file
-          local path = api.nvim_buf_get_name(bufnr)
-          vim.fn.delete(path)
-          -- remove otter buffer
-          api.nvim_buf_delete(bufnr, { force = true })
-        end
-      end
-    end
-  })
 
   if completion then
     for _, otter_nr in pairs(M._otters_attached[main_nr].buffers) do


### PR DESCRIPTION
Hello!

I've been experiencing issue #7, and the fact that I can't consistently reproduce it either is quite annoying. However, I think this PR should fix it! `:h buftype` describes the `nowrite` option:

> The buffer is not to be written to disk, ":w" doesn't work (":w filename" does work though).
> The buffer is never considered to be |'modified'|. There is no warning when the changes will be lost, for example when you quit Vim.

An added bonus is that it's no longer necessary to delete these files upon exiting, because it is not possible to save it.

So far it's working fine for me and I haven't run into the issue again, but I'll attach the caveat that I don't use Quarto regularly enough to be fully confident in saying that it'll never happen. 😄