### PR TITLE
perf: don't set ft on otter buffers

### DIFF
--- a/lua/otter/completion/source.lua
+++ b/lua/otter/completion/source.lua
@@ -1,5 +1,3 @@
-local ts = vim.treesitter
-local tsq = require 'nvim-treesitter.query'
 local keeper = require 'otter.keeper'
 
 local source = {}
@@ -8,7 +6,7 @@ source.new = function(client, main_nr, otter_nr, updater, tsquery)
   local self = setmetatable({}, { __index = source })
   self.client = client
   self.otter_nr = otter_nr
-  self.otter_ft = vim.api.nvim_buf_get_option(otter_nr, 'filetype')
+  self.otter_ft = keeper._otters_attached[main_nr].otter_nr_to_lang[otter_nr]
   self.main_nr = main_nr
   self.main_ft = vim.api.nvim_buf_get_option(main_nr, 'filetype')
   self.otter_parsername = vim.treesitter.language.get_lang(self.otter_ft)
@@ -32,7 +30,7 @@ end
 ---Get debug name.
 ---@return string
 source.get_debug_name = function(self)
-  return table.concat({ 'quarto', self.client.name }, ':')
+  return table.concat({ 'otter', self.client.name }, ':')
 end
 
 ---Return the source is available.
@@ -51,10 +49,13 @@ source.is_available = function(self)
     return false
   end
 
+  -- WORAROUND: disabled check for capabilities for now
+  -- otherwise no completion from html properties
   -- client has no completion capability.
-  if not self:_get(self.client.server_capabilities, { 'completionProvider' }) then
-    return false
-  end
+  -- if not self:_get(self.client.server_capabilities, { 'completionProvider' }) then
+  --   return false
+  -- end
+
   return true;
 end
 

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -236,30 +236,16 @@ M.activate = function(languages, completion, diagnostics, tsquery)
   -- from automatically attaching when ft is set
   for _, lang in ipairs(languages) do
     local otter_nr = M._otters_attached[main_nr].buffers[lang]
-    for k, config in pairs(lspconfigs) do
 
-      local original_on_attach = config.on_attach or function (_, _) end
-      config.on_attach = function (client, bufnr)
-        original_on_attach()
-        if completion then
-          require'otter.completion'.setup_source(main_nr, otter_nr)
-        end
-      end
-
-      if config.filetypes then
-        if contains(config.filetypes, lang) then
-          local client_id = vim.lsp.start(config, { bufnr = otter_nr })
-          if client_id then
-            vim.lsp.buf_attach_client(otter_nr, client_id)
-            local client = vim.lsp.get_client_by_id(client_id)
-          end
-        end
-      end
+    local autocommands = api.nvim_get_autocmds({ group = 'lspconfig', pattern = lang })
+    for _, command in ipairs(autocommands) do
+      local opt = {buf = otter_nr}
+      command.callback(opt)
     end
-  end
 
-  for lang, otter_nr in pairs(M._otters_attached[main_nr].buffers) do
-    -- api.nvim_buf_set_option(otter_nr, 'filetype', lang)
+    if completion then
+      require 'otter.completion'.setup_source(main_nr, otter_nr)
+    end
   end
 
 

--- a/lua/otter/tools/functions.lua
+++ b/lua/otter/tools/functions.lua
@@ -56,13 +56,13 @@ end
 
 
 M.path_to_otterpath = function(path, lang)
-  return path .. '-tmp' .. lang
+  return path .. '.otter' .. lang
 end
 
 --- @param path string a path
 --- @return string
 M.otterpath_to_path = function(path)
-  local s, _ = path:gsub('-tmp%..+', '')
+  local s, _ = path:gsub('.otter%..+', '')
   return s
 end
 
@@ -75,7 +75,7 @@ end
 
 --- @param path string
 M.is_otterpath = function(path)
-  return path:find('.+-tmp%..+') ~= nil
+  return path:find('.+.otter%..+') ~= nil
 end
 
 


### PR DESCRIPTION
to avoid other plugins that we don't need attaching to the otter buffers.
Attach language servers manually by calling the callback from the 'lspconfig' autocommand populated by `setup` on the lspconfigs.