### PR TITLE
Add Markdown and Elixir extensions

### DIFF
--- a/lua/otter/tools/extensions.lua
+++ b/lua/otter/tools/extensions.lua
@@ -10,4 +10,6 @@ return {
   javascript = "js",
   yaml = "yml",
   sql = "sql",
+  elixir = "ex",
+  markdown = "md"
 }


### PR DESCRIPTION
Related to #63,

I had to extend extensions to use `lua require('otter').activate({'markdown'})`. The lack of a markdown extension made the command blow up.

And, since I also use Elixir inside Markdown, I added "ex" to the mix.

wdyt?