### PR TITLE
fix: empty metadata caused treesitter directives like offset to be ignored

### DIFF
--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local fn = require("otter.tools.functions")
 local extensions = require("otter.tools.extensions")
+local treesitter_iterator = require("otter.tools.treesitter_iterator")
 local api = vim.api
 local ts = vim.treesitter
 
@@ -50,15 +51,10 @@ M.extract_code_chunks = function(main_nr, lang, exclude_eval_false, row_from, ro
 
   local code_chunks = {}
   local lang_capture = nil
-  local metadata = {}
-  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
-    if id == 1 then
-      metadata = maybemetadata
-    end
+  for id, node, metadata in treesitter_iterator.iter_captures(root, main_nr, query) do
     local name = query.captures[id]
     local text
     local was_stripped
-
     lang_capture = determine_language(main_nr, name, node, metadata, lang_capture)
     if
         lang_capture
@@ -139,11 +135,7 @@ M.get_current_language_context = function(main_nr)
   local tree = parser:parse()
   local root = tree[1]:root()
   local lang_capture = nil
-  local metadata = {}
-  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
-    if id == 1 then
-      metadata = maybemetadata
-    end
+  for id, node, metadata in treesitter_iterator.iter_captures(root, main_nr, query) do
     local name = query.captures[id]
 
     lang_capture = determine_language(main_nr, name, node, metadata, lang_capture)
@@ -385,11 +377,7 @@ M.get_language_lines_around_cursor = function()
   local tree = parser:parse()
   local root = tree[1]:root()
 
-  local metadata = {}
-  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
-    if id == 1 then
-      metadata = maybemetadata
-    end
+  for id, node, metadata in treesitter_iterator.iter_captures(root, main_nr, query) do
     local name = query.captures[id]
     if name == "content" then
       if ts.is_in_node_range(node, row, col) then

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -50,7 +50,11 @@ M.extract_code_chunks = function(main_nr, lang, exclude_eval_false, row_from, ro
 
   local code_chunks = {}
   local lang_capture = nil
-  for id, node, metadata in query:iter_captures(root, main_nr) do
+  local metadata = {}
+  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
+    if id == 1 then
+      metadata = maybemetadata
+    end
     local name = query.captures[id]
     local text
     local was_stripped
@@ -135,7 +139,11 @@ M.get_current_language_context = function(main_nr)
   local tree = parser:parse()
   local root = tree[1]:root()
   local lang_capture = nil
-  for id, node, metadata in query:iter_captures(root, main_nr) do
+  local metadata = {}
+  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
+    if id == 1 then
+      metadata = maybemetadata
+    end
     local name = query.captures[id]
 
     lang_capture = determine_language(main_nr, name, node, metadata, lang_capture)
@@ -377,7 +385,11 @@ M.get_language_lines_around_cursor = function()
   local tree = parser:parse()
   local root = tree[1]:root()
 
-  for id, node, metadata in query:iter_captures(root, main_nr) do
+  local metadata = {}
+  for id, node, maybemetadata in query:iter_captures(root, main_nr) do
+    if id == 1 then
+      metadata = maybemetadata
+    end
     local name = query.captures[id]
     if name == "content" then
       if ts.is_in_node_range(node, row, col) then

--- a/lua/otter/tools/treesitter_iterator.lua
+++ b/lua/otter/tools/treesitter_iterator.lua
@@ -1,0 +1,31 @@
+M = {}
+
+M.iter_captures = function (node, source, query)
+  if type(source) == "number" and source == 0 then
+    source = vim.api.nvim_get_current_buf()
+  end
+
+  local raw_iter = node:_rawquery(query.query, true, 0, -1)
+  local metadata = {}
+  local function iter(end_line)
+    local capture, captured_node, match = raw_iter()
+
+    if match ~= nil then
+      local active = query:match_preds(match, match.pattern, source)
+      match.active = active
+      if not active then
+        return iter(end_line) -- tail call: try next match
+      else
+        -- if it has an active match, reset the metadata.
+        -- then hopefully apply_directives can fill the metadata
+        metadata = {}
+      end
+      query:apply_directives(match, match.pattern, source, metadata)
+    end
+    return capture, captured_node, metadata
+  end
+  return iter
+end
+
+
+return M


### PR DESCRIPTION
this commit fixes the vim.treesitter.get_node_text from ignoring the offset and possibly other directives like gsub as well.

the reason for this change is that metadata in query:iter_captures was only available if the capture_id is 1 and was reset to an empty table for the captures after that but wasn't replenished and remained empty.

assume that you have a treesitter injection in a rust macro. here's what it would look like

(macro_invocation
 (scoped_identifier
    path: (identifier) @path (#eq? @path "sqlx")
    name: (identifier) @name (#match? @name "^query.*")
 )

 (token_tree
    (raw_string_literal) @injection.content
    (#set! injection.language "sql")
    (#set! injection.include-children)
 )
 (#offset! @injection.content 0 3 0 -2)
)

a raw string in rust looks like this r#"select * from "user";"#

in the #offset! directive raw string start and end identifiers (#r" and "#) are offsetted and what remains is the inner sql.

this offset information is set to the metadata for query.get_node_text to use.

however, it's not available when it needs to be used. in query:iter_captures you get @path capture first then you get @name capture and finally @injection.content capture. metadata is only available in @path capture. which is when the capture_id is 1

this commit sets this to an outside variable and makes it always available.

maybe treesitter needs to fix this as a bug. I don't know honestly.

makes https://github.com/jmbuhr/otter.nvim/issues/79 redundant.
probably fixes https://github.com/jmbuhr/otter.nvim/issues/72 and https://github.com/jmbuhr/otter.nvim/issues/37