### PR TITLE
fix(opts): failing to opt-out features (completion and diagnostics)

### DIFF
--- a/lua/otter/init.lua
+++ b/lua/otter/init.lua
@@ -42,8 +42,8 @@ end
 ---@param diagnostics boolean|nil
 ---@param tsquery string|nil
 M.activate = function(languages, completion, diagnostics, tsquery)
-  completion = completion or true
-  diagnostics = diagnostics or true
+  completion = completion ~= false
+  diagnostics = diagnostics ~= false
   local main_nr = api.nvim_get_current_buf()
   local main_path = api.nvim_buf_get_name(main_nr)
   local parsername = vim.treesitter.language.get_lang(api.nvim_buf_get_option(main_nr, "filetype"))


### PR DESCRIPTION
Following lines become `true` even if the specified values are `false`.
This PR fixes it.

```
  completion = completion or true
  diagnostics = diagnostics or true
```

Now, `nil` and `true` are treated as `true` and `false` is treated as `false`