### PR TITLE
feat: allow nil for languages

### DIFF
--- a/lua/otter/init.lua
+++ b/lua/otter/init.lua
@@ -37,11 +37,12 @@ end
 
 --- Activate the current buffer by adding and syncronizing
 --- otter buffers.
----@param languages table
+---@param languages table|nil
 ---@param completion boolean|nil
 ---@param diagnostics boolean|nil
 ---@param tsquery string|nil
 M.activate = function(languages, completion, diagnostics, tsquery)
+  languages = languages or vim.tbl_keys(require("otter.tools.extensions"))
   completion = completion ~= false
   diagnostics = diagnostics ~= false
   local main_nr = api.nvim_get_current_buf()


### PR DESCRIPTION
Allows you to pass `nil` to `activate()` for languages. When languages is nil, it's set to all the languages that otter supports.

Currently if you pass nil it just errors out, and there is no easy way to just "enable all the languages"

Bonus, there's no errors when you don't have a language server configured for a given language.