### PR TITLE
fix: diagnostics not updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ otter.setup{
     hover = {
       border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
     },
+    -- `:h events` that cause the diagnostics to update. Set to:
+    -- { "BufWritePost", "InsertLeave", "TextChanged" } for less performant
+    -- but more instant diagnostic updates
+    diagnostic_update_events = { "BufWritePost" },
   },
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.
@@ -114,13 +118,13 @@ the embedded code. Use it as follows:
 
 ```lua
 local cmp = require'cmp'
-cmp.setup(
+cmp.setup({
     -- <rest of your nvim-cmp config>
     sources = {
         { name = "otter" },
         -- <other sources>
-    }
-}
+    },
+})
 ```
 
 

--- a/lua/otter/config.lua
+++ b/lua/otter/config.lua
@@ -5,6 +5,7 @@ local default_config = {
     hover = {
       border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
     },
+    diagnostic_update_events = { "BufWritePost" },
   },
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -322,9 +322,6 @@ M.sync_raft = function(main_nr, lang)
     M._otters_attached[main_nr].last_changetick = changetick
     M._otters_attached[main_nr].code_chunks = all_code_chunks
 
-    if next(all_code_chunks) == nil then
-      return
-    end
     local langs
     if lang == nil then
       langs = M._otters_attached[main_nr].languages
@@ -352,7 +349,9 @@ M.sync_raft = function(main_nr, lang)
           end
 
           -- replace language lines
-          api.nvim_buf_set_lines(otter_nr, 0, nmax, false, ls)
+          api.nvim_buf_set_lines(otter_nr, 0, -1, false, ls)
+        else -- no code chunks so we wipe the otter buffer
+          api.nvim_buf_set_lines(otter_nr, 0, -1, false, {})
         end
       end
     end

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -305,7 +305,7 @@ M.modify_position = function(obj, main_nr, invert, exclude_end, known_offset)
   end
 end
 
---- Syncronize the raft of otters attached to a buffer
+--- Synchronize the raft of otters attached to a buffer
 ---@param main_nr integer bufnr of the parent buffer
 ---@param lang string|nil only sync one otter buffer matching a language
 M.sync_raft = function(main_nr, lang)
@@ -314,6 +314,7 @@ M.sync_raft = function(main_nr, lang)
     local changetick = api.nvim_buf_get_changedtick(main_nr)
     if M._otters_attached[main_nr].last_changetick == changetick then
       all_code_chunks = M._otters_attached[main_nr].code_chunks
+      return
     else
       all_code_chunks = M.extract_code_chunks(main_nr)
     end
@@ -322,7 +323,7 @@ M.sync_raft = function(main_nr, lang)
     M._otters_attached[main_nr].code_chunks = all_code_chunks
 
     if next(all_code_chunks) == nil then
-      return {}
+      return
     end
     local langs
     if lang == nil then
@@ -350,9 +351,7 @@ M.sync_raft = function(main_nr, lang)
             end
           end
 
-          -- clear buffer
-          api.nvim_buf_set_lines(otter_nr, 0, -1, false, {})
-          -- add language lines
+          -- replace language lines
           api.nvim_buf_set_lines(otter_nr, 0, nmax, false, ls)
         end
       end


### PR DESCRIPTION
fixes an issue mentioned in conversation in #81

No longer will you have to write the file twice to see the most up to date diagnostics! The reason that this was happening before is that we just weren't giving the LS long enough to give up new diagnostics before trying to refresh them. This caused some really really annoying behavior.

This PR makes use of the `DiagnosticChagned` event (which I didn't know existed until a few hours ago) to update diagnostics in the buffers we're interested in _after_ the LS has updated the diagnostics.

I've also fixed a few small bugs in `sync_raft` which were previously only just using more CPU cycles, they were messing with this change, causing diagnostics to flicker.

~~as I'm writing this, i remembered that I didn't update the `deactivate` method. I'll do that quickly before I go to sleep.~~ I don't need to do that.

