### PR TITLE
fix: users' `lsp.root_dir` config not respected when starting lsp

### DIFF
--- a/lua/otter/lsp/init.lua
+++ b/lua/otter/lsp/init.lua
@@ -1,4 +1,3 @@
-local cfg = require("otter.config").cfg
 local handlers = require("otter.lsp.handlers")
 local keeper = require("otter.keeper")
 local ms = vim.lsp.protocol.Methods
@@ -117,7 +116,7 @@ otterls.start = function(main_nr, completion)
     end,
     before_init = function(_, _) end,
     on_init = function(client, init_result) end,
-    root_dir = cfg.lsp.root_dir(),
+    root_dir = require("otter.config").cfg.lsp.root_dir(),
   })
 
   return client_id


### PR DESCRIPTION
Previously custom `root_dor` is not used when starting otter language server. This patch fixes this issue by requiring the config module on starting the language server (after it merges with user's custom config).