### PR TITLE
refactor: use vim.fs.root() not lspconfig to find project root directory

### DIFF
--- a/.neoconf.json
+++ b/.neoconf.json
@@ -4,8 +4,7 @@
       "enabled": true,
       "plugins": [
         "otter.nvim",
-        "nvim-lspconfig",
-        "lsp",
+        "lsp"
       ]
     }
   },
@@ -13,10 +12,7 @@
     "plugins": {
       "sumneko_lua": {
         "enabled": true
-      },
+      }
     }
-  },
-  "lspconfig": {
-    "sumneko_lua": {}
   }
 }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ handle the response and doesn't pass it on to the default handler.
 
 ```lua
 {
-  'neovim/nvim-lspconfig',
   'nvim-treesitter/nvim-treesitter'
 }
 ```
@@ -126,10 +125,7 @@ handle the response and doesn't pass it on to the default handler.
     'jmbuhr/otter.nvim',
     dev = true,
     dependencies = {
-      {
-        'neovim/nvim-lspconfig',
-        'nvim-treesitter/nvim-treesitter',
-      },
+      'nvim-treesitter/nvim-treesitter',
     },
     opts = {},
 },
@@ -148,7 +144,13 @@ otter.setup{
     -- but more instant diagnostic updates
     diagnostic_update_events = { "BufWritePost" },
     -- function to find the root dir where the otter-ls is started
-    root_dir = require("lspconfig").util.root_pattern({ ".git", "_quarto.yml", "package.json" }),
+    root_dir = function()
+      return vim.fs.root(0, {
+        ".git",
+        "_quarto.yml",
+        "package.json",
+      }) or vim.fn.getcwd(0)
+    end,
   },
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.

--- a/doc/otter.nvim.txt
+++ b/doc/otter.nvim.txt
@@ -218,7 +218,6 @@ DEPENDENCIES ~
 >lua
     {
       'hrsh7th/nvim-cmp', -- optional, for completion
-      'neovim/nvim-lspconfig',
       'nvim-treesitter/nvim-treesitter'
     }
 <

--- a/lua/otter/config.lua
+++ b/lua/otter/config.lua
@@ -3,7 +3,13 @@ local M = {}
 local default_config = {
   lsp = {
     diagnostic_update_events = { "BufWritePost" },
-    root_dir = require("lspconfig").util.root_pattern({ ".git", "_quarto.yml", "package.json" }),
+    root_dir = function()
+      return vim.fs.root(0, {
+        ".git",
+        "_quarto.yml",
+        "package.json",
+      }) or vim.fn.getcwd(0)
+    end,
   },
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.

--- a/lua/otter/lsp/init.lua
+++ b/lua/otter/lsp/init.lua
@@ -1,4 +1,3 @@
-local cfg = require("otter.config").cfg
 local handlers = require("otter.lsp.handlers")
 local keeper = require("otter.keeper")
 local ms = vim.lsp.protocol.Methods
@@ -117,7 +116,7 @@ otterls.start = function(main_nr, completion)
     end,
     before_init = function(_, _) end,
     on_init = function(client, init_result) end,
-    root_dir = cfg.lsp.root_dir(),
+    root_dir = require("otter.config").cfg.lsp.root_dir(),
   })
 
   return client_id

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -28,7 +28,6 @@ function M.setup()
   vim.opt.packpath = { M.root(".tests/site") }
   M.load("nvim-lua/plenary.nvim")
   M.load("nvim-treesitter/nvim-treesitter")
-  M.load("neovim/nvim-lspconfig")
   vim.env.XDG_CONFIG_HOME = M.root(".tests/config")
   vim.env.XDG_DATA_HOME = M.root(".tests/data")
   vim.env.XDG_STATE_HOME = M.root(".tests/state")


### PR DESCRIPTION
Currently nvim-lspconfig is a hard dependency but it is only used to find the projec root directory.

This patch uses nvim's builtin `vim.fs.root()` instead of nvim-lspconfig's util functikion to find the project root directory. This eliminates the hard requirements of nvim-lspconfig as a dependency which is good for users that does not use nvim-lspconfig.

