### PR TITLE
fix: use schedule_wrap to avoid text_lock

### DIFF
--- a/lua/otter/lsp/init.lua
+++ b/lua/otter/lsp/init.lua
@@ -32,7 +32,7 @@ otterls.start = function(main_nr, completion)
         --- depending on the method it is either our custom handler
         --- (e.g. for retargeting got-to-definition results)
         --- or the default vim.lsp.handlers[method] handler
-        request = function(method, params, handler, _)
+        request = vim.schedule_wrap(function(method, params, handler, _)
           -- handle initialization first
           if method == ms.initialize then
             local completion_options
@@ -162,7 +162,7 @@ otterls.start = function(main_nr, completion)
             end
             handler(err, result, context, config)
           end)
-        end,
+        end),
         notify = function(method, params)
           -- we don't actually notify otter buffers
           -- they get their notifications


### PR DESCRIPTION
Should fix #183, #182, #178

For the minimal reproduction I used the following `minimal.lua`

```lua
vim.env.LAZY_STDPATH = ".repro"
load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()

require("lazy.minit").repro({
	spec = {
		{
			"jmbuhr/otter.nvim",
			dependencies = {
				{
					"nvim-treesitter/nvim-treesitter",
					ensure_installed = {
						"markdown",
					},
				},
			},
			opts = {},
		},
		{
			"neovim/nvim-lspconfig",
			dependencies = {
				{
					"williamboman/mason-lspconfig.nvim",
					dependencies = { "mason.nvim" },
					opts = {
						ensure_installed = { "lua_ls" },
					},
				},
				{
					"williamboman/mason.nvim",
					build = ":MasonUpdate",
					opts = {},
				},
			},
			config = function()
				local lspconfig = require("lspconfig")
				lspconfig.lua_ls.setup({})
			end,
		},
	},
})

vim.api.nvim_create_autocmd("LspAttach", {
	callback = function(args)
		vim.api.nvim_buf_attach(args.buf, false, {
			on_lines = function()
				local method = "textDocument/documentColor"
				local param = { textDocument = vim.lsp.util.make_text_document_params() }
				local clients = vim.lsp.get_clients({ bufnr = args.buf, method = method })
				for _, client in ipairs(clients) do
					client.request(method, param, function() end)
				end
			end,
		})
	end,
})

vim.keymap.set("n", "<F4>", function()
	vim.cmd.edit("/tmp/test.md")
	vim.api.nvim_buf_set_lines(0, 0, -1, true, { "```lua", 'local a = "a"', "```" })
	require("otter").activate()
	vim.defer_fn(function()
		vim.cmd.normal("gg0joa")
	end, 1000)
end)
```

nvim-lspconfig, mason and mason-lspconfig are simply being used to ease the installation and configuration of `lua-ls` and have nothing to do with this issue.

Steps:

1. `nvim -u minimal.lua`
2. Wait for `lazy.nvim` to download the plugins, for `nvim-treesitter` to install the `markdown` parser and for `mason.nvim` to install lua_ls
3. Press `<F4>` (the F4 key)

A file `/tmp/test.md` will be opened with the following text:

````md
```lua
local a = "a"
```
````

the cursor will be moved to the `local a = 'a'` line, a new line will be inserted downwards and the text `a` will be written. This will cause an error without this PR and will work fine with this PR.

The method `textDocument/documentColor` is being used simply because I first found this error while using [cc.nvim](https://github.com/uga-rosa/ccc.nvim)