### PR TITLE
feat: postamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,23 @@ otter.setup{
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.
     -- otherwise only the autocommand of lspconfig that attaches
-    -- the language server will be executed without setting the filetype  
-    set_filetype = false,
+    -- the language server will be executed without setting the filetype
+    set_filetype = true,
     -- write <path>.otter.<embedded language extension> files
     -- to disk on save of main buffer.
-    -- usefule for some linters that require actual files
+    -- usefule for some linters that require actual files.
     -- otter files are deleted on quit or main buffer close
     write_to_disk = false,
+    -- a table of preambles for each language. The key is the language and the value is a table of strings that will be written to the otter buffer starting on the first line.
+    preambles = {},
+    -- a table of postambles for each language. The key is the language and the value is a table of strings that will be written to the end of the otter buffer.
+    postambles = {},
+    -- A table of patterns to ignore for each language. The key is the language and the value is a lua match pattern to ignore.
+    -- lua patterns: https://www.lua.org/pil/20.2.html
+    ignore_pattern = {
+      -- ipython cell magic (lines starting with %) and shell commands (lines starting with !)
+      python = "^(%s*[%%!].*)",
+    },
   },
   -- list of characters that should be stripped from the beginning and end of the code chunks
   strip_wrapping_quote_characters = { "'", '"', "`" },

--- a/lua/otter/config.lua
+++ b/lua/otter/config.lua
@@ -21,15 +21,17 @@ local default_config = {
   buffers = {
     -- if set to true, the filetype of the otterbuffers will be set.
     -- otherwise only the autocommand of lspconfig that attaches
-    -- the language server will be executed without setting the filetype  
+    -- the language server will be executed without setting the filetype
     set_filetype = true,
     -- write <path>.otter.<embedded language extension> files
     -- to disk on save of main buffer.
     -- usefule for some linters that require actual files.
     -- otter files are deleted on quit or main buffer close
     write_to_disk = false,
-    --A table of preambles for each language. The key is the language and the value is a table of strings that will be written to the otter buffer starting on the first line.
+    -- a table of preambles for each language. The key is the language and the value is a table of strings that will be written to the otter buffer starting on the first line.
     preambles = {},
+    -- a table of postambles for each language. The key is the language and the value is a table of strings that will be written to the end of the otter buffer.
+    postambles = {},
     -- A table of patterns to ignore for each language. The key is the language and the value is a lua match pattern to ignore.
     -- lua patterns: https://www.lua.org/pil/20.2.html
     ignore_pattern = {

--- a/lua/otter/init.lua
+++ b/lua/otter/init.lua
@@ -37,12 +37,14 @@ M.export_otter_as = keeper.export_otter_as
 ---@param diagnostics boolean? Enable diagnostics for otter buffers. Default: true
 ---@param tsquery string? Explicitly provide a treesitter query. If nil, the injections query for the current filetyepe will be used. See :h treesitter-language-injections.
 ---@paramr preambles table? A table of preambles for each language. The key is the language and the value is a table of strings that will be written to the otter buffer starting on the first line.
+---@paramr postambles table? A table of postambles for each language. The key is the language and the value is a table of strings that will be written to the end of the otter buffer.
 ---@paramr ignore_pattern table? A table of patterns to ignore for each language. The key is the languang and the value is a regular expression string to match patterns to ignore.
-M.activate = function(languages, completion, diagnostics, tsquery, preambles, ignore_pattern)
+M.activate = function(languages, completion, diagnostics, tsquery, preambles, postambles, ignore_pattern)
   languages = languages or vim.tbl_keys(require("otter.tools.extensions"))
   completion = completion ~= false
   diagnostics = diagnostics ~= false
   preambles = preambles or config.cfg.buffers.preambles
+  postambles = postambles or config.cfg.buffers.postambles
   ignore_pattern = ignore_pattern or config.cfg.buffers.ignore_pattern
   local main_nr = api.nvim_get_current_buf()
   local main_path = api.nvim_buf_get_name(main_nr)
@@ -76,6 +78,7 @@ M.activate = function(languages, completion, diagnostics, tsquery, preambles, ig
     buffers = {},
     paths = {},
     preambles = {},
+    postambles = {},
     ignore_pattern = {},
     otter_nr_to_lang = {},
     tsquery = tsquery,
@@ -128,6 +131,7 @@ M.activate = function(languages, completion, diagnostics, tsquery, preambles, ig
       keeper.rafts[main_nr].buffers[lang] = otter_nr
       keeper.rafts[main_nr].paths[lang] = otter_path
       keeper.rafts[main_nr].preambles[lang] = preambles[lang] or {}
+      keeper.rafts[main_nr].postambles[lang] = postambles[lang] or {}
       keeper.rafts[main_nr].ignore_pattern[lang] = ignore_pattern[lang] or nil
       keeper.rafts[main_nr].otter_nr_to_lang[otter_nr] = lang
       table.insert(keeper.rafts[main_nr].languages, lang)

--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -16,6 +16,7 @@ local cfg = require("otter.config").cfg
 ---@field buffers table<string, integer>
 ---@field paths table<string, string>
 ---@field preambles table<string, string[]>
+---@field postambles table<string, string[]>
 ---@field ignore_pattern table<string, string>
 ---@field otter_nr_to_lang table<integer, string>
 ---@field tsquery string?
@@ -449,6 +450,12 @@ keeper.sync_raft = function(main_nr, language)
               ls[index] = l
             end
           end
+        end
+
+        -- set postamble lines
+        local postamble = keeper.rafts[main_nr].postambles[lang]
+        for _, l in ipairs(postamble) do
+          table.insert(ls, l)
         end
 
         -- set code lines


### PR DESCRIPTION
this is an "extension" of https://github.com/jmbuhr/otter.nvim/issues/99 which was fixed in https://github.com/jmbuhr/otter.nvim/pull/212 for adding lines *after* the main buffer.

this is useful for e.g. wrapping languages with c-style syntax in codeblocks, e.g. for top-level `await` in javascript:

```ts
async function main() {  // preamble
await something();       // main buffer
}                        // postamble
```

"postamble" isn't actually a word, but i think it gets the job done to indicate it being the counterpart to preambles.

i also updated the README with the latest default configuration, since it didn't mention a few things yet.
