### PR TITLE
Add Swift language support

### DIFF
--- a/lua/otter/config.lua
+++ b/lua/otter/config.lua
@@ -81,6 +81,7 @@ OtterConfig = {
     sh = "sh",
     sql = "sql",
     svelte = "svelte",
+    swift = "swift",
     tex = "tex",
     typescript = "ts",
     typst = "typ",


### PR DESCRIPTION
Simple addition of Swift to the supported extensions list in config.lua. This enables Swift code blocks to work properly in markdown and quarto documents.

Tested locally and confirmed working with Swift LSP completion in code blocks.