### PR TITLE
fix(spelling): "ottter" -> "otter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ otter.setup{
   },
   -- list of characters that should be stripped from the beginning and end of the code chunks
   strip_wrapping_quote_characters = { "'", '"', "`" },
-  -- remove whitespace from the beginning of the code chunks when writing to the ottter buffers
+  -- remove whitespace from the beginning of the code chunks when writing to the otter buffers
   -- and calculate it back in when handling lsp requests
   handle_leading_whitespace = true,
   -- mapping of filetypes to extensions for those not already included in otter.tools.extensions

--- a/lua/otter/config.lua
+++ b/lua/otter/config.lua
@@ -39,7 +39,7 @@ OtterConfig = {
   },
   -- list of characters that should be stripped from the beginning and end of the code chunks
   strip_wrapping_quote_characters = { "'", '"', "`" },
-  -- remove whitespace from the beginning of the code chunks when writing to the ottter buffers
+  -- remove whitespace from the beginning of the code chunks when writing to the otter buffers
   -- and calculate it back in when handling lsp requests
   handle_leading_whitespace = true,
   -- mapping of filetypes to extensions for those not already included in otter.tools.extensions


### PR DESCRIPTION
Just noticed a little spelling error in the example while I was looking through things.

EDIT: Noticed the same error in `config.lua` too, fixed it there.