### PR TITLE
fix: missing OtterConfig on injectable_languages

### DIFF
--- a/lua/otter/keeper.lua
+++ b/lua/otter/keeper.lua
@@ -704,7 +704,7 @@ keeper.get_language_lines_around_cursor = function()
   end
 
   -- Check if this language is in our injectable languages list
-  if not fn.contains(injectable_languages, lang) then
+  if not fn.contains(OtterConfig.injectable_languages, lang) then
     return nil
   end
 

--- a/tests/core/extraction_spec.lua
+++ b/tests/core/extraction_spec.lua
@@ -251,6 +251,25 @@ describe("code extraction", function()
 
       cleanup(bufnr)
     end)
+
+    it("returns code when cursor is inside a code block", function()
+      local bufnr = load_and_activate("minimal.md")
+
+      -- Move cursor inside lua code block (line 9 in minimal.md)
+      api.nvim_win_set_cursor(0, { 9, 5 })
+
+      local code = keeper.get_language_lines_around_cursor()
+      assert.is_not_nil(code, "should return code when cursor is in code block")
+      assert.is_true(code:find("greet") ~= nil, "should contain expected code")
+
+      -- Move cursor outside code block (line 3)
+      api.nvim_win_set_cursor(0, { 3, 0 })
+
+      code = keeper.get_language_lines_around_cursor()
+      assert.is_nil(code, "should return nil when cursor is outside code block")
+
+      cleanup(bufnr)
+    end)
   end)
 
   describe("indentation preservation", function()


### PR DESCRIPTION
Hi @jmbuhr,

This PR is to include what I believe is a missing `OtterConfg.` preceding an `injectable_languages` in `keeper.lua`. Also included are two tests for the `get_language_lines_around_cursor` function to verify usage (looking for code when inside of a block and `nil` when outside). I used my best judgement in placing the tests and following convention, please let me know if I've missed or misunderstood anything; happy to make any changes you'd like.


Thank you!
