### PR TITLE
fix: fix OtterActivate and OtterDeactivate user commands

### DIFF
--- a/plugin/otter.lua
+++ b/plugin/otter.lua
@@ -1,9 +1,12 @@
-
 -- make OtterConfig globally available
 require("otter.config")
 
-vim.api.nvim_create_user_command("OtterActivate", require("otter").activate, {})
-vim.api.nvim_create_user_command("OtterDeactivate", require("otter").deactivate, {})
+vim.api.nvim_create_user_command("OtterActivate", function()
+  require("otter").activate()
+end, {})
+vim.api.nvim_create_user_command("OtterDeactivate", function()
+  require("otter").deactivate()
+end, {})
 vim.api.nvim_create_user_command("OtterExport", function(opts)
   require("otter").export(opts.bang == true)
 end, { bang = true })


### PR DESCRIPTION
A function to activate otter was called with `args` from user
command, which caused otter to not load, because of unmatched languages.
This commit wraps calling of activate function to anonymous function.
