### PR TITLE
fix: don't mutate request params in place (silently broken hover/definition on Neovim 0.12)

### DIFF
--- a/lua/otter/lsp/init.lua
+++ b/lua/otter/lsp/init.lua
@@ -94,6 +94,14 @@ otterls.start = function(main_nr, completion)
             return
           end
 
+          -- Neovim keeps a reference to the params table of a request
+          -- (ctx.params) and compares its position against the current
+          -- cursor when the response arrives (ctx_is_valid in vim.lsp.buf,
+          -- since Neovim 0.12). Mutating params in place makes that check
+          -- fail, so hover/definition responses get silently dropped.
+          -- Work on a copy instead.
+          params = vim.deepcopy(params)
+
           -- container to pass additional information to otter and the handlers
           if params.otter == nil then
             ---@type OtterParams


### PR DESCRIPTION
## Problem

On Neovim 0.12, `vim.lsp.buf.hover()`, `definition()`, and friends silently do nothing in otter-activated buffers — no float, no "No information available" message, nothing.

Neovim keeps a reference to the request's `params` table and, when the response arrives, validates it against the current editor state (`ctx_is_valid` in `runtime/lua/vim/lsp/buf.lua`): the cursor must still be at `ctx.params.position`, otherwise the response is discarded as stale.

otter-ls modifies that same table in place in its `request` function (`lua/otter/lsp/init.lua`): it rewrites `textDocument.uri` to the otter buffer and shifts `position.character` to account for stripped leading whitespace. Since Lua tables are passed by reference, Neovim's staleness check then compares the cursor against the *shifted* position, concludes the cursor moved, and drops the response.

The raw LSP round-trip works fine (a direct `client:request()` returns proper hover contents), which makes this quite confusing to debug — everything looks attached and healthy.

## Fix

Deep-copy `params` before modifying it, so the caller's table stays intact. One line plus a comment.

## Repro

- Neovim 0.12, any otter-activated buffer (e.g. an HTML file with a `<script>` block and tsserver/tsgo attached via otter)
- Cursor on an identifier at any position where the code chunk has leading indentation, press `K`
- Before: nothing happens. After: hover float as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)